### PR TITLE
Fix missing bcryptjs module error

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -31,6 +31,12 @@ if [ ! -d "node_modules" ]; then
     npm install
 fi
 
+# Ensure critical modules are installed even if node_modules exists
+if [ ! -f "node_modules/bcryptjs/package.json" ]; then
+    echo "Missing bcryptjs module, installing..."
+    npm install bcryptjs
+fi
+
 if [ ! -d "client/node_modules" ]; then
     echo "Installing frontend dependencies..."
     cd client && npm install && cd ..


### PR DESCRIPTION
## Summary
- ensure `run.sh` installs `bcryptjs` automatically if not present

## Testing
- `./run.sh > /tmp/run_output.log && tail -n 20 /tmp/run_output.log`
- `./run.sh > /tmp/run_output2.log && tail -n 20 /tmp/run_output2.log`

------
https://chatgpt.com/codex/tasks/task_e_6846f947a364832ab547557b4e5119e5