### PR TITLE
Use shared api instance in Dashboard

### DIFF
--- a/client/src/components/Dashboard.js
+++ b/client/src/components/Dashboard.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import axios from 'axios';
+import { api } from '../services/api';
 
 const Dashboard = () => {
   const [stats, setStats] = useState(null);
@@ -13,10 +13,10 @@ const Dashboard = () => {
 
   const fetchDashboardData = async () => {
     try {
-      const [statsRes, activityRes, healthRes] = await Promise.all([
-        axios.get(`${API_BASE}/api/dashboard/stats`),
-        axios.get(`${API_BASE}/api/dashboard/activity`),
-        axios.get(`${API_BASE}/health`)
+    const [statsRes, activityRes, healthRes] = await Promise.all([
+        api.get('/dashboard/stats'),
+        api.get('/dashboard/activity'),
+        api.get('/health', { baseURL: API_BASE })
       ]);
 
       setStats(statsRes.data);

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -43,3 +43,5 @@ export const vacationRequestAPI = {
   approve: (id, supervisorId) => api.put(`/vacation-requests/${id}/approve`, { supervisor_id: supervisorId }),
   deny: (id, data) => api.put(`/vacation-requests/${id}/deny`, data)
 };
+
+export { api };


### PR DESCRIPTION
## Summary
- export Axios instance in api.js
- use the exported instance in Dashboard for dashboard data

## Testing
- `npm test --prefix client`

------
https://chatgpt.com/codex/tasks/task_e_6849b15c38c8832a912221f78c0438d5