### PR TITLE
Implement password reset via email or phone

### DIFF
--- a/client/src/components/EmployeeManager.js
+++ b/client/src/components/EmployeeManager.js
@@ -11,6 +11,7 @@ const EmployeeManager = () => {
     first_name: '',
     last_name: '',
     email: '',
+    phone: '',
     location_id: '',
     role: 'employee',
     supervisor_id: ''
@@ -76,6 +77,7 @@ const EmployeeManager = () => {
       first_name: employee.first_name,
       last_name: employee.last_name,
       email: employee.email,
+      phone: employee.phone || '',
       location_id: employee.location_id?.toString() || '',
       role: employee.role,
       supervisor_id: employee.supervisor_id?.toString() || ''
@@ -100,6 +102,7 @@ const EmployeeManager = () => {
       first_name: '',
       last_name: '',
       email: '',
+      phone: '',
       location_id: '',
       role: 'employee',
       supervisor_id: ''
@@ -153,6 +156,7 @@ const EmployeeManager = () => {
             <tr>
               <th>Name</th>
               <th>Email</th>
+              <th>Phone</th>
               <th>Location</th>
               <th>Role</th>
               <th>Supervisor</th>
@@ -164,6 +168,7 @@ const EmployeeManager = () => {
               <tr key={employee.id}>
                 <td>{employee.first_name} {employee.last_name}</td>
                 <td>{employee.email}</td>
+                <td>{employee.phone || 'N/A'}</td>
                 <td>{getLocationName(employee.location_id)}</td>
                 <td>{employee.role}</td>
                 <td>{getSupervisorName(employee.supervisor_id)}</td>
@@ -227,18 +232,28 @@ const EmployeeManager = () => {
                     />
                   </div>
                   <div className="form-group mb-3">
-                    <label>Email</label>
-                    <input
-                      type="email"
-                      className="form-control"
-                      name="email"
-                      value={formData.email}
-                      onChange={handleInputChange}
-                      required
-                    />
-                  </div>
-                  <div className="form-group mb-3">
-                    <label>Location</label>
+                  <label>Email</label>
+                  <input
+                    type="email"
+                    className="form-control"
+                    name="email"
+                    value={formData.email}
+                    onChange={handleInputChange}
+                    required
+                  />
+                </div>
+                <div className="form-group mb-3">
+                  <label>Phone</label>
+                  <input
+                    type="text"
+                    className="form-control"
+                    name="phone"
+                    value={formData.phone}
+                    onChange={handleInputChange}
+                  />
+                </div>
+                <div className="form-group mb-3">
+                  <label>Location</label>
                     <select
                       className="form-control"
                       name="location_id"

--- a/client/src/components/Login.js
+++ b/client/src/components/Login.js
@@ -31,7 +31,6 @@ const Login = ({ onLogin }) => {
     }
   };
 
-
   return (
     <div className="login-container">
       <h2>{showReset ? 'Password Reset' : 'Login'}</h2>
@@ -120,3 +119,4 @@ const Login = ({ onLogin }) => {
 };
 
 export default Login;
+

--- a/client/src/components/Login.js
+++ b/client/src/components/Login.js
@@ -8,8 +8,6 @@ const Login = ({ onLogin }) => {
   const [error, setError] = useState(null);
   const [showReset, setShowReset] = useState(false);
   const [resetSent, setResetSent] = useState(false);
-  const [resetCode, setResetCode] = useState('');
-  const [newPassword, setNewPassword] = useState('');
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -33,21 +31,10 @@ const Login = ({ onLogin }) => {
     }
   };
 
-  const handleResetConfirm = async (e) => {
-    e.preventDefault();
-    try {
-      await authAPI.resetPassword({ email, phone, token: resetCode, password: newPassword });
-      setShowReset(false);
-      setResetSent(false);
-      setError(null);
-    } catch (err) {
-      setError('Password reset failed');
-    }
-  };
 
   return (
     <div className="login-container">
-      <h2>{showReset ? 'Reset Password' : 'Login'}</h2>
+      <h2>{showReset ? 'Password Reset' : 'Login'}</h2>
       {error && <p style={{ color: 'red' }}>{error}</p>}
 
       {!showReset && (
@@ -97,27 +84,7 @@ const Login = ({ onLogin }) => {
       )}
 
       {showReset && resetSent && (
-        <form onSubmit={handleResetConfirm}>
-          <div className="form-group">
-            <input
-              type="text"
-              placeholder="Reset Code"
-              value={resetCode}
-              onChange={(e) => setResetCode(e.target.value)}
-              required
-            />
-          </div>
-          <div className="form-group">
-            <input
-              type="password"
-              placeholder="New Password"
-              value={newPassword}
-              onChange={(e) => setNewPassword(e.target.value)}
-              required
-            />
-          </div>
-          <button type="submit" className="btn btn-primary">Reset Password</button>
-        </form>
+        <p>Reset instructions sent.</p>
       )}
 
       {!showReset && (
@@ -136,16 +103,16 @@ const Login = ({ onLogin }) => {
 
       {showReset && (
         <p>
-          <button
-            type="button"
-            className="btn btn-link"
-            onClick={() => {
+          <a
+            href="#"
+            onClick={(e) => {
+              e.preventDefault();
               setShowReset(false);
               setResetSent(false);
             }}
           >
             Back to Login
-          </button>
+          </a>
         </p>
       )}
     </div>

--- a/client/src/components/Login.js
+++ b/client/src/components/Login.js
@@ -3,8 +3,13 @@ import { authAPI } from '../services/api';
 
 const Login = ({ onLogin }) => {
   const [email, setEmail] = useState('');
+  const [phone, setPhone] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState(null);
+  const [showReset, setShowReset] = useState(false);
+  const [resetSent, setResetSent] = useState(false);
+  const [resetCode, setResetCode] = useState('');
+  const [newPassword, setNewPassword] = useState('');
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -18,31 +23,131 @@ const Login = ({ onLogin }) => {
     }
   };
 
+  const handleResetRequest = async (e) => {
+    e.preventDefault();
+    try {
+      await authAPI.requestReset({ email, phone });
+      setResetSent(true);
+    } catch (err) {
+      setError('Reset request failed');
+    }
+  };
+
+  const handleResetConfirm = async (e) => {
+    e.preventDefault();
+    try {
+      await authAPI.resetPassword({ email, phone, token: resetCode, password: newPassword });
+      setShowReset(false);
+      setResetSent(false);
+      setError(null);
+    } catch (err) {
+      setError('Password reset failed');
+    }
+  };
+
   return (
     <div className="login-container">
-      <h2>Login</h2>
+      <h2>{showReset ? 'Reset Password' : 'Login'}</h2>
       {error && <p style={{ color: 'red' }}>{error}</p>}
-      <form onSubmit={handleSubmit}>
-        <div className="form-group">
-          <input
-            type="email"
-            placeholder="Email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            required
-          />
-        </div>
-        <div className="form-group">
-          <input
-            type="password"
-            placeholder="Password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            required
-          />
-        </div>
-        <button type="submit" className="btn btn-primary">Login</button>
-      </form>
+
+      {!showReset && (
+        <form onSubmit={handleSubmit}>
+          <div className="form-group">
+            <input
+              type="email"
+              placeholder="Email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+            />
+          </div>
+          <div className="form-group">
+            <input
+              type="password"
+              placeholder="Password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+            />
+          </div>
+          <button type="submit" className="btn btn-primary">Login</button>
+        </form>
+      )}
+
+      {showReset && !resetSent && (
+        <form onSubmit={handleResetRequest}>
+          <div className="form-group">
+            <input
+              type="email"
+              placeholder="Email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+            />
+          </div>
+          <div className="form-group">
+            <input
+              type="text"
+              placeholder="Phone"
+              value={phone}
+              onChange={(e) => setPhone(e.target.value)}
+            />
+          </div>
+          <button type="submit" className="btn btn-primary">Send Code</button>
+        </form>
+      )}
+
+      {showReset && resetSent && (
+        <form onSubmit={handleResetConfirm}>
+          <div className="form-group">
+            <input
+              type="text"
+              placeholder="Reset Code"
+              value={resetCode}
+              onChange={(e) => setResetCode(e.target.value)}
+              required
+            />
+          </div>
+          <div className="form-group">
+            <input
+              type="password"
+              placeholder="New Password"
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+              required
+            />
+          </div>
+          <button type="submit" className="btn btn-primary">Reset Password</button>
+        </form>
+      )}
+
+      {!showReset && (
+        <p className="mt-2">
+          <a
+            href="#"
+            onClick={(e) => {
+              e.preventDefault();
+              setShowReset(true);
+            }}
+          >
+            Forgot or Change Password?
+          </a>
+        </p>
+      )}
+
+      {showReset && (
+        <p>
+          <button
+            type="button"
+            className="btn btn-link"
+            onClick={() => {
+              setShowReset(false);
+              setResetSent(false);
+            }}
+          >
+            Back to Login
+          </button>
+        </p>
+      )}
     </div>
   );
 };

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -13,7 +13,9 @@ api.interceptors.request.use(config => {
 });
 
 export const authAPI = {
-  login: data => axios.post(`${API_BASE}/login`, data)
+  login: data => axios.post(`${API_BASE}/login`, data),
+  requestReset: data => axios.post(`${API_BASE}/request-password-reset`, data),
+  resetPassword: data => axios.post(`${API_BASE}/reset-password`, data)
 };
 
 export const employeeAPI = {

--- a/models/Employee.js
+++ b/models/Employee.js
@@ -18,6 +18,11 @@ const employeeSchema = new mongoose.Schema({
     trim: true,
     lowercase: true
   },
+  phone: {
+    type: String,
+    required: false,
+    trim: true
+  },
   password: {
     type: String,
     required: true
@@ -35,6 +40,14 @@ const employeeSchema = new mongoose.Schema({
   supervisor_id: {
     type: mongoose.Schema.Types.ObjectId,
     ref: 'Employee',
+    required: false
+  },
+  resetToken: {
+    type: String,
+    required: false
+  },
+  resetTokenExpiration: {
+    type: Date,
     required: false
   }
 }, {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "cors": "^2.8.5",
         "express": "^4.18.2",
         "jsonwebtoken": "^9.0.0",
-        "mongoose": "^7.5.0"
+        "mongoose": "^7.5.0",
+        "nodemailer": "^6.9.3"
       },
       "devDependencies": {
         "nodemon": "^3.0.1"
@@ -1061,6 +1062,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "6.9.3",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.9.3.tgz",
+      "integrity": "sha512-fy9v3NgTzBngrMFkDsKEj0r02U7jm6XfC3b52eoNV+GCrGj+s8pt5OqhiJdWKuw51zCTdiNR/IUD1z33LIIGpg==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/nodemon": {

--- a/package.json
+++ b/package.json
@@ -9,16 +9,21 @@
     "mongodb": "node server_mongodb.js"
   },
   "dependencies": {
-    "express": "^4.18.2",
-    "cors": "^2.8.5",
-    "mongoose": "^7.5.0",
     "bcryptjs": "^2.4.3",
-    "jsonwebtoken": "^9.0.0"
+    "cors": "^2.8.5",
+    "express": "^4.18.2",
+    "jsonwebtoken": "^9.0.0",
+    "mongoose": "^7.5.0",
+    "nodemailer": "^6.9.3"
   },
   "devDependencies": {
     "nodemon": "^3.0.1"
   },
-  "keywords": ["vacation", "express", "node"],
+  "keywords": [
+    "vacation",
+    "express",
+    "node"
+  ],
   "author": "",
   "license": "ISC"
 }


### PR DESCRIPTION
## Summary
- add phone and reset token fields to Employee model
- implement request-password-reset and reset-password routes
- send reset code via email or log as SMS
- support password reset UI and phone field in Employee manager
- expose password reset APIs in the client
- add nodemailer dependency
- add a visible link to invoke the password reset flow from the login screen

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6849fe05631c832a94bfd6cc3d3b7f60