### PR TITLE
Replace Jest with Mocha and Vitest

### DIFF
--- a/client/jest.config.js
+++ b/client/jest.config.js
@@ -1,6 +1,0 @@
-module.exports = {
-  testEnvironment: 'jsdom',
-  transformIgnorePatterns: [
-    '/node_modules/(?!(axios)/)'
-  ],
-};

--- a/client/package.json
+++ b/client/package.json
@@ -12,13 +12,12 @@
   "scripts": {
     "start": "NODE_OPTIONS='--openssl-legacy-provider' react-scripts start",
     "build": "NODE_OPTIONS='--openssl-legacy-provider' react-scripts build",
-    "test": "react-scripts test",
+    "test": "vitest",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {
     "extends": [
-      "react-app",
-      "react-app/jest"
+      "react-app"
     ]
   },
   "browserslist": {
@@ -36,11 +35,6 @@
   "proxy": "http://localhost:3001",
   "devDependencies": {
     "@testing-library/react": "^14.2.0",
-    "babel-jest": "^24.8.0"
-  },
-  "jest": {
-    "transformIgnorePatterns": [
-      "/node_modules/(?!(axios)/)"
-    ]
+    "vitest": "^0.34.4"
   }
 }

--- a/client/src/App.test.js
+++ b/client/src/App.test.js
@@ -1,7 +1,10 @@
 import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
 import App from './App';
 
-it('renders Login component by default', () => {
-  render(<App />);
-  expect(screen.getByText(/login/i)).toBeInTheDocument();
+describe('App', () => {
+  it('renders Login component by default', () => {
+    render(<App />);
+    expect(screen.getByText(/login/i)).toBeInTheDocument();
+  });
 });

--- a/client/vitest.config.js
+++ b/client/vitest.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom'
+  }
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  testEnvironment: 'node',
-  testPathIgnorePatterns: ['/node_modules/', '/client/'],
-};

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "node server.js",
     "dev": "nodemon server.js",
     "mongodb": "node server_mongodb.js",
-    "test": "jest",
+    "test": "mocha \"tests/**/*.test.js\"",
     "test:client": "npm test --prefix client"
   },
   "dependencies": {
@@ -19,8 +19,8 @@
     "nodemailer": "^6.9.3"
   },
   "devDependencies": {
-    "jest": "^27.5.1",
-    "babel-jest": "^24.8.0",
+    "mocha": "^10.2.0",
+    "chai": "^4.3.7",
     "nodemon": "^3.0.1",
     "supertest": "^7.1.1"
   },

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -1,24 +1,25 @@
 const request = require('supertest');
+const { expect } = require('chai');
 const app = require('../server');
 
 describe('Vacation API', () => {
   it('GET / should return API info', async () => {
     const res = await request(app).get('/');
-    expect(res.statusCode).toBe(200);
-    expect(res.body).toHaveProperty('message', 'Vacation Request Management API');
+    expect(res.statusCode).to.equal(200);
+    expect(res.body).to.have.property('message', 'Vacation Request Management API');
   });
 
   it('GET /api/employees should return list of employees', async () => {
     const res = await request(app).get('/api/employees');
-    expect(res.statusCode).toBe(200);
-    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.statusCode).to.equal(200);
+    expect(res.body).to.be.an('array');
   });
 
   it('POST /api/employees should create a new employee', async () => {
     const newEmp = { name: 'Test User', email: 'test@example.com', department: 'IT', location: 'Remote' };
     const res = await request(app).post('/api/employees').send(newEmp);
-    expect(res.statusCode).toBe(200);
-    expect(res.body).toHaveProperty('id');
-    expect(res.body).toMatchObject(newEmp);
+    expect(res.statusCode).to.equal(200);
+    expect(res.body).to.have.property('id');
+    expect(res.body).to.include(newEmp);
   });
 });


### PR DESCRIPTION
## Summary
- swap backend tests to use Mocha and Chai
- configure frontend tests to run with Vitest
- remove Jest configs
- add Vitest config for client

## Testing
- `npm test --silent`
- `./run.sh > /tmp/run_output.txt && ./stop.sh`
- `./run-simple.sh > /tmp/run_simple_output.txt && ./stop.sh`


------
https://chatgpt.com/codex/tasks/task_e_684b35b7ce8c832a913513a245d82320