### PR TITLE
Add basic login route

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,13 +1,48 @@
 const express = require('express');
 const cors = require('cors');
+const jwt = require('jsonwebtoken');
 
 const api = require('./routes/api');
 
 const app = express();
 const PORT = process.env.PORT || 3001;
+const JWT_SECRET = process.env.JWT_SECRET || 'in-memory-secret';
+
+const demoUser = {
+  id: 1,
+  first_name: 'Demo',
+  last_name: 'User',
+  email: 'demo@company.com',
+  password: 'password',
+  role: 'administrator',
+  location_id: 1
+};
 
 app.use(cors());
 app.use(express.json());
+
+app.post('/api/login', (req, res) => {
+  const { email, password } = req.body;
+  if (email === demoUser.email && password === demoUser.password) {
+    const token = jwt.sign(
+      { id: demoUser.id, role: demoUser.role, location_id: demoUser.location_id },
+      JWT_SECRET,
+      { expiresIn: '1h' }
+    );
+    return res.json({
+      token,
+      user: {
+        id: demoUser.id,
+        first_name: demoUser.first_name,
+        last_name: demoUser.last_name,
+        email: demoUser.email,
+        role: demoUser.role,
+        location_id: demoUser.location_id
+      }
+    });
+  }
+  res.status(401).json({ error: 'Invalid credentials' });
+});
 
 // Root route with API overview
 app.get('/', (req, res) => {


### PR DESCRIPTION
## Summary
- implement /api/login in the lightweight server
- provide demo user with JWT token generation

## Testing
- `npm test --silent`
- `./run.sh > /tmp/run_output.txt && ./stop.sh`
- `./run-simple.sh > /tmp/run_simple_output.txt && ./stop.sh`


------
https://chatgpt.com/codex/tasks/task_e_684c3124c6f0832ab44ead8453ae249a